### PR TITLE
fix passing of menuContext into SwipeableDrawer

### DIFF
--- a/packages/material-ui-shell/src/containers/ResponsiveMenu/ResponsiveMenu.js
+++ b/packages/material-ui-shell/src/containers/ResponsiveMenu/ResponsiveMenu.js
@@ -8,7 +8,7 @@ import { useConfig } from 'base-shell/lib/providers/Config'
 const iOS = process.browser && /iPad|iPhone|iPod/.test(navigator.userAgent)
 
 const CustomSwipeableDrawer = styled(SwipeableDrawer)(
-  ({ theme, isDesktop, isMenuOpen, isMiniMode, width }) => {
+  ({ theme, width, menucontext: { isDesktop, isMenuOpen, isMiniMode } }) => {
     if (isDesktop) {
       return {
         '& .MuiDrawer-paper': {
@@ -61,7 +61,7 @@ const ResponsiveMenu = ({ children }) => {
   return (
     <div style={{ boxSizing: 'content-box' }}>
       <CustomSwipeableDrawer
-        {...menuContext}
+        menucontext={menuContext}
         width={width}
         disableBackdropTransition={!iOS}
         disableDiscovery={iOS}


### PR DESCRIPTION
Prevent throwing multiple error messages due to recognizing camel case spelled custom attributes on DOM elements.

Error example: React does not recognize the `isDesktop` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isdesktop` instead. If you accidentally passed it from a parent component, remove it from the DOM element.